### PR TITLE
Do not install packages in editable mode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -102,7 +102,7 @@ then
         echo "----------------------- $file ------------------------------"
         cd $file
         rm -rf build dist
-        pip install --force-reinstall -e .
+        pip install --force-reinstall .
         cd ../..
     done
 fi


### PR DESCRIPTION
Do not install from local git repos using pip with editable mode, as
that only adds a reference from the virtual environment to the source
code in the local git repo, and does not install the source code into
the virtual environment.

Editable mode is problematic because when creating a package from the
virtual environment, not everything is contained within the virtual
environment, with packages installed by pip in editable mode residing
outside the virtual environment and not ending up in the tarball.
